### PR TITLE
Add docker workflow for main/latest

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           node-version: '12'
           check-latest: true
-      - name: Install node modules 
+      - name: Install node modules
         run: npm install --also=dev
-      - name: Do local build 
+      - name: Do local build
         run: npm run-script build
-      - name: Do production build 
+      - name: Do production build
         run: npm run-script build-production
       - name: Do docker image build
         run: docker build -t apiman-devportal:latest .
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install node modules
         run: npm install --also=dev
-      - name: Do browser tests 
+      - name: Do browser tests
         run: npm run-script test
         env:
           #Uses the default chrome browser from the ubuntu-latest image
@@ -55,3 +55,16 @@ jobs:
           files: junit/api-mgmt-dev-portal/*.xml
           report_individual_runs: true
           deduplicate_classes_by_file_name: false
+
+  Publish:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.repository_owner == 'Apiman'
+    steps:
+      # Build and push new Docker images
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+      - name: Building Docker Images
+        run: docker build . --file Dockerfile --tag apiman/developer-portal:latest
+      - name: Push The Tagged Docker Images
+        run: docker push apiman/developer-portal:latest
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,8 +31,6 @@ jobs:
         run: npm run-script build
       - name: Do production build
         run: npm run-script build-production
-      - name: Do docker image build
-        run: docker build -t apiman-devportal:latest .
   Tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  Builds:
+  Build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -31,7 +31,7 @@ jobs:
         run: npm run-script build
       - name: Do production build
         run: npm run-script build-production
-  Tests:
+  Test:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -55,6 +55,7 @@ jobs:
           deduplicate_classes_by_file_name: false
 
   Publish:
+    needs: [Build, Test]
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.repository_owner == 'Apiman'
     steps:


### PR DESCRIPTION
The first draft of a docker-workflow:

I would go with the name `apiman/developer-portal`. So it may then show also up if somebody searches for `developer portal` instead of only `devportal`. 

@EricWittmann I could not look up the docker hub passwords in the main project. Maybe you can add them here or provide the secrets for the whole org, so every project could use them? :)
