### PR TITLE
Changed getAllUsers to getDevPortalUsers

### DIFF
--- a/src/app/components/admin/create-developer/create-developer.component.spec.ts
+++ b/src/app/components/admin/create-developer/create-developer.component.spec.ts
@@ -57,8 +57,8 @@ describe('CreateDeveloperComponent', () => {
     }
   }];
 
-  const adminService = jasmine.createSpyObj('adminService', ['getKeycloakUsers', 'getAllClients']);
-  adminService.getKeycloakUsers.and.returnValue(from(
+  const adminService = jasmine.createSpyObj('adminService', ['getDevPortalUsers', 'getAllClients']);
+  adminService.getDevPortalUsers.and.returnValue(from(
     keycloakUsers
   ));
   adminService.getAllClients.and.returnValue(from(

--- a/src/app/components/admin/create-developer/create-developer.component.ts
+++ b/src/app/components/admin/create-developer/create-developer.component.ts
@@ -57,7 +57,7 @@ export class CreateDeveloperComponent implements OnInit, OnDestroy {
    * On init life circle
    */
   ngOnInit(): void {
-    const getKeycloakUserTask = this.adminService.getKeycloakUsers().pipe(map(keycloakUsers => {
+    const getKeycloakUserTask = this.adminService.getDevPortalUsers().pipe(map(keycloakUsers => {
       this.keycloakUsers = keycloakUsers;
       this.filteredKeycloakUsers = keycloakUsers.filter((user => this.checkDeveloperNotExists(user.username)));
     }));

--- a/src/app/components/admin/services/admin.service.ts
+++ b/src/app/components/admin/services/admin.service.ts
@@ -15,8 +15,8 @@
  */
 
 import {Inject, Injectable} from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {catchError, map, mergeMap} from 'rxjs/operators';
+import {from, Observable, of} from 'rxjs';
+import {mergeMap} from 'rxjs/operators';
 import {ClientSearchResult, Developer} from '../../../services/api-data.service';
 import {HttpClient} from '@angular/common/http';
 import {KeycloakInteractionService} from './keycloak-interaction.service';
@@ -57,8 +57,8 @@ export class AdminService {
   /**
    * Get all keycloak users
    */
-  public getKeycloakUsers() {
-    return this.keycloak.getAllUsers();
+  public getDevPortalUsers() {
+    return from(this.keycloak.getDevPortalUsers());
   }
 
   /**


### PR DESCRIPTION
To add a developer, the developer must be selected from the list of all Keycloak users.
To make this list a bit clearer, only the users assigned to the Developer Portal groups are now displayed.

![DeveloperList](https://user-images.githubusercontent.com/19830745/105846143-0833fa00-5fdc-11eb-8016-27a3f0f69a1d.png)
