### PR TITLE
chore: switch import to filled material icons

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,7 +44,7 @@
               "node_modules/swagger-ui/dist/swagger-ui.css",
               "node_modules/simplebar/dist/simplebar.min.css",
               "node_modules/prismjs/themes/prism.css",
-              "node_modules/material-icons/iconfont/material-icons.css"
+              "node_modules/material-icons/iconfont/filled.css"
             ],
             "scripts": [
               "node_modules/marked/marked.min.js",


### PR DESCRIPTION
Only bundle material icons we use in the project.
For more details have a look at: https://github.com/marella/material-icons#reducing-build-size

Closes: #115